### PR TITLE
add: tables filtered by client

### DIFF
--- a/Phase3/app/client/main.php
+++ b/Phase3/app/client/main.php
@@ -1,3 +1,6 @@
+<?php
+    session_start();
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/Phase3/app/client/projects.php
+++ b/Phase3/app/client/projects.php
@@ -3,7 +3,6 @@ session_start();
 //fetch projects data
 if (isset($_SESSION['projectData'])) {
     $projectData = $_SESSION['projectData'];
-    unset($_SESSION['projectData']);
 } else {
     $projectData = [];
 }

--- a/Phase3/app/client/viewEmp.php
+++ b/Phase3/app/client/viewEmp.php
@@ -3,7 +3,6 @@ session_start();
 //fetch projects data
 if (isset($_SESSION['viewEmp'])) {
     $viewEmp = $_SESSION['viewEmp'];
-    unset($_SESSION['viewEmp']);
 } else {
     $viewEmp = [];
 }
@@ -22,7 +21,8 @@ if (isset($_SESSION['viewEmp'])) {
                 <thead>
                     <tr>
                         <th>Project Name</th>
-                        <th>SSN</th>
+                        <th>First Name</th>
+                        <th>Last Name</th>
                         <th>Email</th>
                         <th>Address</th>
                         <th>Phone</th>
@@ -32,7 +32,8 @@ if (isset($_SESSION['viewEmp'])) {
                     <?php foreach ($viewEmp as $row): ?>
                         <tr>
                             <td data-title="Project Name"><?php echo ($row["Pname"]); ?></td>
-                            <td data-title="SSN"><?php echo ($row["Ssn"]); ?></td>
+                            <td data-title="First Name"><?php echo ($row["Fname"]); ?></td>
+                            <td data-title="Last Name"><?php echo ($row["Lname"]); ?></td>
                             <td data-title="Email"><?php echo ($row["Email"]); ?></td>
                             <td data-title="Address"><?php echo ($row["Address"]); ?></td>
                             <td data-title="Phone"><?php echo ($row["Phone"]); ?></td>

--- a/Phase3/app/client/viewManager.php
+++ b/Phase3/app/client/viewManager.php
@@ -3,7 +3,6 @@ session_start();
 //fetch projects data
 if (isset($_SESSION['viewManager'])) {
     $viewManager = $_SESSION['viewManager'];
-    unset($_SESSION['viewManager']);
 } else {
     $viewManager = [];
 }
@@ -21,7 +20,8 @@ if (isset($_SESSION['viewManager'])) {
             <table id="table">
                 <thead>
                     <tr>
-                        <th>Mgr_ssn</th>
+                        <th>First Name</th>
+                        <th>Last Name</th>
                         <th>Project Name</th>
                         <th>Email</th>
                         <th>Phone</th>
@@ -31,8 +31,9 @@ if (isset($_SESSION['viewManager'])) {
                 <tbody>
                     <?php foreach ($viewManager as $row): ?>
                         <tr>
-                            <td data-title="Mgr_ssn"><?php echo ($row["Mgr_ssn"]); ?></td>
-                            <td data-title="Pname"><?php echo ($row["Pname"]); ?></td>
+                            <td data-title="First Name"><?php echo ($row["Fname"]); ?></td>
+                            <td data-title="Last Name"><?php echo ($row["Lname"]); ?></td>
+                            <td data-title="Project Name"><?php echo ($row["Pname"]); ?></td>
                             <td data-title="Email"><?php echo ($row["Email"]); ?></td>
                             <td data-title="Phone"><?php echo ($row["Phone"]); ?></td>
                             <td data-title="Address"><?php echo ($row["Address"]); ?></td>


### PR DESCRIPTION
When client clicks a button on the main client page, the tables that are outputted only show the projects the client logged in assigned, and the employee and managers that are working on the projects the client assigned to them.

Also fixed the issue where the tables disappear when you refresh the tables page.